### PR TITLE
Fix: Disable game buttons after 3 rounds & ensure computer choice updates

### DIFF
--- a/games/rps.html
+++ b/games/rps.html
@@ -80,13 +80,13 @@
             <div class="text-center mb-8">
                 <h3 class="text-xl font-bold mb-4">Make Your Choice:</h3>
                 <div class="flex justify-center gap-4 flex-wrap">
-                    <button onclick="playGame('rock')" class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110">
+                    <button onclick="playGame('rock')" class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110 rps-button">
                         <span class="text-4xl mr-2">🪨</span>Rock
                     </button>
-                    <button onclick="playGame('paper')" class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110">
+                    <button onclick="playGame('paper')" class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110 rps-button">
                         <span class="text-4xl mr-2">📄</span>Paper
                     </button>
-                    <button onclick="playGame('scissors')" class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110">
+                    <button onclick="playGame('scissors')" class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110 rps-button">
                         <span class="text-4xl mr-2">✂️</span>Scissors
                     </button>
                 </div>

--- a/scripts/rps.js
+++ b/scripts/rps.js
@@ -21,6 +21,7 @@ const maxRounds = 3;
 
 // Play game
 function playGame(playerChoice) {
+  if (roundCount >= maxRounds) return;
   const computerChoice = getComputerChoice();
   const result = determineWinner(playerChoice, computerChoice);
 
@@ -35,6 +36,7 @@ function playGame(playerChoice) {
   // show final result
   if (roundCount >= maxRounds) {
     updateResult("final", playerChoice, computerChoice);
+    disableGameButtons();
   } else {
     updateResult(result, playerChoice, computerChoice, roundCount);
   }
@@ -95,7 +97,6 @@ function updateResult(result, playerChoice, computerChoice, roundCount = 0) {
       message = `🤝 The match is a draw! (${scores.player} - ${scores.computer})   👉 Click 'Reset' to start a new game.`;
       alertClass = "alert alert-warning";
     }
-    
   } else {
     message = `Round ${roundCount} of 3: `;
     if (result === "player") {
@@ -107,8 +108,7 @@ function updateResult(result, playerChoice, computerChoice, roundCount = 0) {
     } else {
       message += `It's a draw! You both chose ${choices[playerChoice].name}.`;
       alertClass = "alert alert-warning";
-    }   
-
+    }
   }
 
   resultText.textContent = message;
@@ -154,6 +154,21 @@ function resetGame() {
   document.getElementById("playerChoice").textContent = "❓";
   document.getElementById("computerChoice").textContent = "❓";
   document.getElementById("gameResult").classList.add("hidden");
+
+  //   Enable game buttons
+  enableGameButtons();
+}
+
+// Disable game buttons
+function disableGameButtons() {
+  const button = document.querySelectorAll(".rps-button");
+  button.forEach((btn) => (btn.disable = true));
+}
+
+// Enable game buttons
+function enableGameButtons() {
+  const button = document.querySelectorAll(".rps-button");
+  button.forEach((btn) => (btn.disable = false));
 }
 
 // Initialize game when page loads


### PR DESCRIPTION
## 📄 Description

This PR fixes the issue where players could continue clicking Rock/Paper/Scissors even after completing all rounds.
It also ensures that the computer’s choice updates correctly with every valid player action.

Key updates include:

* Added logic to **disable all game buttons after 3 rounds** to prevent extra moves.
* Ensured **computer choice refreshes every round** and reflects a new random value.
* Re-enabled buttons through the Reset function so the player can start a new match smoothly.

This ensures proper game flow and prevents unintended interactions during or after gameplay.

---

## 🔗 Related Issues

Fixes #31 

---

## 🖼️ Screenshots (if applicable)
  

https://github.com/user-attachments/assets/e55835d4-b6e7-4dc6-9c23-bbaa584fb62f



---

## 🧩 Type of Change

* [x] 🐛 Bug Fix
* [ ] ✨ New Feature
* [ ] ⚡ Enhancement / Optimization
* [ ] 🧰 Refactoring
* [ ] 🧾 Documentation Update
* [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

* [x] I have performed a self-review of my code.
* [x] I have commented my code where needed.
* [x] I have ensured the fix does not break any existing functionality.
* [x] I have tested the changes locally and verified the correct behavior.
* [x] I have linked the relevant issue.

---

