### PR TITLE
feat: integrate drf-spectacular for OpenAPI 3.0 docs & Swagger UI (#352)

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -14,6 +14,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes, force_str
 from django.core.mail import send_mail
 from django.conf import settings
+from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
 import json
 
 
@@ -26,6 +27,30 @@ def get_user_profile(user):
 # AUTH ENDPOINTS
 # ============================================================
 
+@extend_schema(
+    tags=['Authentication'],
+    summary='Login with username/email and password',
+    description=(
+        'Authenticates a user and returns a JWT access token and refresh token. '
+        'Accepts either a **username** or **email** in the `username` field.'
+    ),
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {
+                'username': {'type': 'string', 'description': 'Username or email address'},
+                'password': {'type': 'string', 'description': 'Account password'},
+            },
+            'required': ['username', 'password'],
+        }
+    },
+    responses={
+        200: OpenApiResponse(description='Login successful. Returns access, refresh tokens and user data.'),
+        400: OpenApiResponse(description='Missing required fields.'),
+        401: OpenApiResponse(description='Invalid username or password.'),
+        403: OpenApiResponse(description='Account is inactive.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_login(request):
@@ -68,6 +93,32 @@ def api_login(request):
     })
 
 
+@extend_schema(
+    tags=['Authentication'],
+    summary='Register a new player account',
+    description=(
+        'Creates a new GameHub user account and returns JWT tokens for immediate login. '
+        'All fields are required. Email and username must be unique across the system.'
+    ),
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {
+                'first_name': {'type': 'string'},
+                'last_name': {'type': 'string'},
+                'username': {'type': 'string', 'description': 'Must be unique'},
+                'email': {'type': 'string', 'format': 'email', 'description': 'Must be unique'},
+                'password1': {'type': 'string', 'description': 'Password'},
+                'password2': {'type': 'string', 'description': 'Confirm password (must match password1)'},
+            },
+            'required': ['first_name', 'last_name', 'username', 'email', 'password1', 'password2'],
+        }
+    },
+    responses={
+        201: OpenApiResponse(description='Registration successful. Returns tokens and user object.'),
+        400: OpenApiResponse(description='Validation error — missing fields, passwords do not match, or duplicate username/email.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_register(request):
@@ -115,6 +166,12 @@ def api_register(request):
         return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
+@extend_schema(
+    tags=['Authentication'],
+    summary='Logout (client-side token invalidation)',
+    description='JWT logout is handled client-side by deleting the stored tokens. This endpoint confirms the logout action.',
+    responses={200: OpenApiResponse(description='Logged out successfully.')},
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_logout(request):
@@ -123,6 +180,25 @@ def api_logout(request):
     return Response({'message': 'Logged out successfully.'})
 
 
+@extend_schema(
+    tags=['Authentication'],
+    summary='Request a password reset email',
+    description=(
+        'Sends a password reset link to the given email if an account exists. '
+        'In **DEBUG mode**, the reset URL is also returned in the response body for testing.'
+    ),
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {'email': {'type': 'string', 'format': 'email'}},
+            'required': ['email'],
+        }
+    },
+    responses={
+        200: OpenApiResponse(description='Reset email sent (or silently skipped if no account found).'),
+        400: OpenApiResponse(description='Email is required.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_forgot_password(request):
@@ -156,6 +232,26 @@ def api_forgot_password(request):
     return Response(response_data)
 
 
+@extend_schema(
+    tags=['Authentication'],
+    summary='Confirm password reset with token',
+    description='Validates the UID and token from the reset email and sets the new password.',
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {
+                'uid': {'type': 'string', 'description': 'Base64-encoded user ID from reset link'},
+                'token': {'type': 'string', 'description': 'Password reset token from email link'},
+                'password': {'type': 'string', 'description': 'The new password to set'},
+            },
+            'required': ['uid', 'token', 'password'],
+        }
+    },
+    responses={
+        200: OpenApiResponse(description='Password reset successful.'),
+        400: OpenApiResponse(description='Invalid or expired token, or missing fields.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_reset_password(request):
@@ -180,6 +276,22 @@ def api_reset_password(request):
         return Response({'error': 'Invalid or expired reset link.'}, status=status.HTTP_400_BAD_REQUEST)
 
 
+@extend_schema(
+    tags=['Authentication'],
+    summary='Refresh JWT access token',
+    description='Accepts a valid refresh token and returns a new access token.',
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {'refresh': {'type': 'string', 'description': 'A valid JWT refresh token'}},
+            'required': ['refresh'],
+        }
+    },
+    responses={
+        200: OpenApiResponse(description='New access token returned.'),
+        401: OpenApiResponse(description='Refresh token is invalid or expired.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_token_refresh(request):
@@ -199,6 +311,19 @@ def api_token_refresh(request):
 # USER / PROFILE
 # ============================================================
 
+@extend_schema(
+    tags=['Profile'],
+    summary='Get authenticated user profile',
+    description=(
+        'Returns the current user\'s data, profile stats (visits, plays, score), '
+        'and all per-game high scores. **Requires Bearer token.**\n\n'
+        'Score formula: `visits + (plays × 5)`'
+    ),
+    responses={
+        200: OpenApiResponse(description='User profile, stats and game scores returned successfully.'),
+        401: OpenApiResponse(description='Authentication credentials were not provided or are invalid.'),
+    },
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def api_profile(request):
@@ -235,6 +360,15 @@ def api_profile(request):
 # LEADERBOARD
 # ============================================================
 
+@extend_schema(
+    tags=['Leaderboard'],
+    summary='Get global player leaderboard',
+    description=(
+        'Returns all players ranked by their total score in descending order. '
+        'Score formula: `visits + (plays × 5)`. No authentication required.'
+    ),
+    responses={200: OpenApiResponse(description='Ranked list of all players with their stats.')},
+)
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def api_leaderboard(request):
@@ -259,6 +393,15 @@ def api_leaderboard(request):
 # GAME TRACKING
 # ============================================================
 
+@extend_schema(
+    tags=['Game Tracking'],
+    summary='Record a game page visit',
+    description='Increments the authenticated user\'s visit counter by 1. Called when a game page is opened.',
+    responses={
+        200: OpenApiResponse(description='Visit recorded. Returns updated visits, plays, and score.'),
+        500: OpenApiResponse(description='Internal server error.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def api_add_visit(request):
@@ -273,6 +416,15 @@ def api_add_visit(request):
         return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
+@extend_schema(
+    tags=['Game Tracking'],
+    summary='Record a game play',
+    description='Increments the authenticated user\'s play counter by 1. Worth 5× more than a visit in score calculation.',
+    responses={
+        200: OpenApiResponse(description='Play recorded. Returns updated visits, plays, and score.'),
+        500: OpenApiResponse(description='Internal server error.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def api_add_play(request):
@@ -286,6 +438,25 @@ def api_add_play(request):
         return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
+@extend_schema(
+    tags=['Game Tracking'],
+    summary='Save a game high score',
+    description='Saves the player\'s score for a specific game. Only updates if the new score is **higher** than the current high score.',
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {
+                'game_id': {'type': 'string', 'description': 'Unique slug of the game (e.g. `snake`, `tetris`)'},
+                'score': {'type': 'integer', 'description': 'The score achieved in this session'},
+            },
+            'required': ['game_id', 'score'],
+        }
+    },
+    responses={
+        200: OpenApiResponse(description='Score saved or updated. Returns the current high score.'),
+        400: OpenApiResponse(description='Missing game_id or score.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def api_save_score(request):
@@ -310,6 +481,24 @@ def api_save_score(request):
 # FEEDBACK
 # ============================================================
 
+@extend_schema(
+    tags=['Feedback'],
+    summary='Submit user feedback or a support message',
+    description='Stores a message from the user (or an anonymous visitor) in the database.',
+    request={
+        'application/json': {
+            'type': 'object',
+            'properties': {
+                'content': {'type': 'string', 'description': 'The feedback message content'},
+            },
+            'required': ['content'],
+        }
+    },
+    responses={
+        200: OpenApiResponse(description='Feedback received successfully.'),
+        400: OpenApiResponse(description='Content field is required.'),
+    },
+)
 @api_view(['POST'])
 @permission_classes([AllowAny])
 def api_send_feedback(request):

--- a/backend/gamehub_project/settings.py
+++ b/backend/gamehub_project/settings.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_simplejwt',
     'corsheaders',
+    'drf_spectacular',
     'accounts',
 ]
 
@@ -92,6 +93,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 # ============================================================
@@ -124,3 +126,46 @@ CORS_ALLOW_HEADERS = [
 # ============================================================
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DEFAULT_FROM_EMAIL = 'noreply@gamehub.cosmos'
+
+# ============================================================
+# DRF Spectacular — OpenAPI 3.0 Schema Configuration
+# ============================================================
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'GameHub API — Cosmic Edition',
+    'DESCRIPTION': (
+        'The official REST API documentation for **GameHub: Cosmic Edition**. \n\n'
+        'All endpoints are served under `/api/`. Authentication uses **JWT Bearer tokens** — '
+        'login via `/api/auth/login/` to receive your `access` and `refresh` tokens, '
+        'then pass the `access` token in the `Authorization: Bearer <token>` header.\n\n'
+        '**Base URL:** `http://localhost:8000`'
+    ),
+    'VERSION': '2.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'CONTACT': {
+        'name': 'GameHub Development Team',
+        'email': 'support@gamehub.cosmos',
+    },
+    'LICENSE': {
+        'name': 'MIT License',
+    },
+    # Group endpoints by tag (maps to URL path prefixes)
+    'TAGS': [
+        {'name': 'Authentication', 'description': 'Login, registration, JWT token management, and password reset flows.'},
+        {'name': 'Profile', 'description': 'Retrieve or manage the authenticated user\'s profile and game statistics.'},
+        {'name': 'Leaderboard', 'description': 'Global leaderboard ranked by player score (visits + plays × 5).'},
+        {'name': 'Game Tracking', 'description': 'Track game visits, plays, and submit high scores.'},
+        {'name': 'Feedback', 'description': 'Submit user feedback or contact messages.'},
+    ],
+    # Swagger UI enhancements
+    'SWAGGER_UI_SETTINGS': {
+        'deepLinking': True,
+        'persistAuthorization': True,
+        'displayOperationId': False,
+        'defaultModelsExpandDepth': 2,
+    },
+    # Security — define JWT Bearer scheme for Swagger "Authorize" button
+    'SECURITY': [{'BearerAuth': []}],
+    'PREPROCESSING_HOOKS': ['drf_spectacular.hooks.preprocess_exclude_path_format'],
+    'POSTPROCESSING_HOOKS': ['drf_spectacular.hooks.postprocess_schema_enums'],
+    'COMPONENT_SPLIT_REQUEST': True,
+}

--- a/backend/gamehub_project/urls.py
+++ b/backend/gamehub_project/urls.py
@@ -2,10 +2,25 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView,
+    SpectacularRedocView,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('accounts.urls')),
+
+    # ============================================================
+    # API Documentation
+    # /api/schema/  → Download raw OpenAPI 3.0 YAML schema
+    # /api/docs/    → Swagger UI (interactive playground)
+    # /api/redoc/   → Redoc (clean, readable reference docs)
+    # ============================================================
+    path('api/schema/', SpectacularAPIView.as_view(), name='api-schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='api-schema'), name='api-swagger-ui'),
+    path('api/redoc/', SpectacularRedocView.as_view(url_name='api-schema'), name='api-redoc'),
 ]
 
 if settings.DEBUG:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ djangorestframework-simplejwt
 django-cors-headers
 Pillow
 python-dotenv
+drf-spectacular


### PR DESCRIPTION
## feat: Integrate DRF Spectacular for Automated API Documentation(#352)

**Closes #352**

---

### Summary

Previously, GameHub's backend endpoints were discovered through trial and error — no developer reference existed. This PR integrates **`drf-spectacular`** to auto-generate a fully interactive **OpenAPI 3.0** schema from the existing codebase, making frontend-backend integration significantly faster for all contributors.

---

### Changes Made

#### [requirements.txt](cci:7://file:///c:/Users/LENOVO/Desktop/GameHub/backend/requirements.txt:0:0-0:0)
- Added `drf-spectacular` as a backend dependency

#### [settings.py](cci:7://file:///c:/Users/LENOVO/Desktop/GameHub/backend/gamehub_project/settings.py:0:0-0:0)
- Added `drf_spectacular` to `INSTALLED_APPS`
- Set `DEFAULT_SCHEMA_CLASS` to `drf_spectacular.openapi.AutoSchema` in `REST_FRAMEWORK`
- Added full `SPECTACULAR_SETTINGS` configuration:
  - API title: **"GameHub API — Cosmic Edition"**
  - Version: `2.0.0`
  - JWT Bearer auth button in Swagger UI ("Authorize")
  - 5 organized endpoint tags: `Authentication`, [Profile](cci:1://file:///c:/Users/LENOVO/Desktop/GameHub/frontend/src/pages/ProfilePage.jsx:19:0-254:2), `Leaderboard`, `Game Tracking`, `Feedback`
  - `persistAuthorization: true` — token survives page refresh in Swagger

####  [gamehub_project/urls.py](cci:7://file:///c:/Users/LENOVO/Desktop/GameHub/backend/gamehub_project/urls.py:0:0-0:0) — 3 New Documentation Endpoints

| URL | Description |
|---|---|
| `GET /api/schema/` | Download raw **OpenAPI 3.0 YAML** schema file |
| `GET /api/docs/` | **Swagger UI** — fully interactive endpoint playground |
| `GET /api/redoc/` | **Redoc** — clean, readable API reference docs |

#### [accounts/views.py](cci:7://file:///c:/Users/LENOVO/Desktop/GameHub/backend/accounts/views.py:0:0-0:0) — `@extend_schema` Added to All 11 Endpoints

Every view is now documented with:
- **Summary** — one-line description shown in the endpoint list
- **Description** — detailed markdown explanation of behavior
- **Request body schema** — exact JSON fields, types, and which are required
- **Response codes** — 200/201/400/401/403/500 with human-readable descriptions
- **Tag** — groups endpoint under the correct category in Swagger

| Tag | Endpoints Documented |
|---|---|
| `Authentication` | Login, Register, Logout, Token Refresh, Forgot Password, Reset Password |
| [Profile](cci:1://file:///c:/Users/LENOVO/Desktop/GameHub/frontend/src/pages/ProfilePage.jsx:19:0-254:2) | Get Profile |
| `Leaderboard` | Global Leaderboard |
| `Game Tracking` | Add Visit, Add Play, Save High Score |
| `Feedback` | Send Feedback / Contact Message |

---

### How to Test Locally

```bash
# Install new dependency
cd backend
pip install -r requirements.txt

# Run the server
python manage.py runserver
```

Then open in browser:

| URL | What you'll see |
|-----|----------------|
| `http://localhost:8000/api/docs/` | Swagger UI — try every endpoint live |
| `http://localhost:8000/api/redoc/` | Clean Redoc reference |
| `http://localhost:8000/api/schema/` | Raw YAML schema download |

To test authenticated endpoints in Swagger:

1. Use `POST /api/auth/login/` → copy the `access` token
2. Click the **Authorize** button at the top
3. Enter: `Bearer <your_access_token>`
4. All protected endpoints now work directly from the browser!

---

##  Screenshots

<img width="1763" height="1635" alt="image" src="https://github.com/user-attachments/assets/443e10db-295f-4ecc-a1cc-b687b9ad8de0" />
<img width="1763" height="8942" alt="image" src="https://github.com/user-attachments/assets/2edc37c1-1f58-4c1d-bbd0-4eff927bd96c" />

---

