### PR TITLE
Insecure production defaults in Django settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,14 @@ VITE_GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 ```env
 SECRET_KEY=your_django_secret_key
 DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
 GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 ```
+
+> [!IMPORTANT]
+> `DEBUG` now defaults to `False` in code. For local development, set `DEBUG=True` in `backend/.env`.
+> In production (`DEBUG=False`), you must provide both `SECRET_KEY` and `ALLOWED_HOSTS`.
 
 > [!TIP]
 > Get your Google OAuth credentials from [console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials).

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ python -m venv venv
 source venv/bin/activate
 
 pip install -r requirements.txt
+# Copy the example environment file and edit values for local development
+cp .env.example .env
+# Edit backend/.env as needed (SECRET_KEY, DEBUG, ALLOWED_HOSTS, Google creds)
 python manage.py migrate
 python manage.py runserver
 # Runs on http://localhost:8000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,14 +1,8 @@
-# ============================================================
 # GameHub Backend — Environment Variables
-# Copy this to .env in the backend/ directory
-# ============================================================
-
-# Django Secret Key
-SECRET_KEY=your-secret-key-here
-
-# Debug mode (True for development)
-DEBUG=True
-
+# Copy this into .env in the backend/ directory
+SECRET_KEY=your-secret-key-here     # Django Secret Key
+DEBUG=True      # Debug mode (True for development)
+ALLOWED_HOSTS=localhost,127.0.0.1       # Comma-separated hosts (required when DEBUG=False)
 # Google OAuth2.0 Credentials (from Google Cloud Console)
 # https://console.cloud.google.com/apis/credentials
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com

--- a/backend/gamehub_project/settings.py
+++ b/backend/gamehub_project/settings.py
@@ -31,7 +31,19 @@ DEBUG = env_bool('DEBUG', False)
 SECRET_KEY = os.environ.get('SECRET_KEY', '').strip()
 if not SECRET_KEY:
     if DEBUG:
-        SECRET_KEY = 'django-insecure-dev-only-change-me'
+        # Generate an ephemeral, in-memory secret for development to avoid
+        # committing a fallback key in source control. This secret will
+        # not persist across process restarts — set `SECRET_KEY` in
+        # `backend/.env` for a persistent local value.
+        import secrets
+        import warnings
+
+        SECRET_KEY = secrets.token_urlsafe(50)
+        warnings.warn(
+            'DEBUG=True and SECRET_KEY not set; using ephemeral in-memory secret. '
+            'For persistent local sessions, set SECRET_KEY in backend/.env',
+            UserWarning
+        )
     else:
         raise ImproperlyConfigured('SECRET_KEY environment variable must be set when DEBUG is False.')
 

--- a/backend/gamehub_project/settings.py
+++ b/backend/gamehub_project/settings.py
@@ -5,17 +5,39 @@ Django settings for gamehub_project project.
 from pathlib import Path
 from datetime import timedelta
 import os
+from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 load_dotenv(BASE_DIR / '.env')
 
-SECRET_KEY = 'django-insecure-bht$bvpl4(l3j3zm3h^b1y%23j&tu^_gm#^i!e=ouf2h7e$e_3'
+def env_bool(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {'1', 'true', 't', 'yes', 'y', 'on'}
 
-DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+def env_list(name, default=''):
+    value = os.environ.get(name, default)
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+DEBUG = env_bool('DEBUG', False)
+
+# Keep a dev-only fallback key to avoid breaking local onboarding.
+# In non-debug environments, SECRET_KEY must be explicitly provided.
+SECRET_KEY = os.environ.get('SECRET_KEY', '').strip()
+if not SECRET_KEY:
+    if DEBUG:
+        SECRET_KEY = 'django-insecure-dev-only-change-me'
+    else:
+        raise ImproperlyConfigured('SECRET_KEY environment variable must be set when DEBUG is False.')
+
+ALLOWED_HOSTS = env_list('ALLOWED_HOSTS', 'localhost,127.0.0.1') if DEBUG else env_list('ALLOWED_HOSTS')
+if not DEBUG and not ALLOWED_HOSTS:
+    raise ImproperlyConfigured('ALLOWED_HOSTS environment variable must be set when DEBUG is False.')
 
 
 INSTALLED_APPS = [


### PR DESCRIPTION
## 📄 Description

This PR hardens the Django backend configuration by removing insecure production defaults and moving security-sensitive settings to environment-driven values.

It updates settings.py so that:
- `SECRET_KEY` is loaded from environment variables
- `DEBUG` defaults to `False`
- `ALLOWED_HOSTS` is no longer hardcoded to `*`
- production startup now fails fast when required environment values are missing

It also updates the documentation and environment templates so local development remains simple while production stays safe by default.

---

## 🔗 Related Issues

Fixes #362 

---

## 🖼️ Screenshots (if applicable)
<img width="1251" height="318" alt="Screenshot 2026-05-15 at 12 37 06 AM" src="https://github.com/user-attachments/assets/85b2e04b-4e3c-4364-9895-dba9ba3af4df" />
<img width="1119" height="361" alt="Screenshot 2026-05-15 at 12 37 21 AM" src="https://github.com/user-attachments/assets/f7f8ed65-e413-49d8-b070-2f093f87e652" />

---

## 🧩 Type of Change

Select the type of change your PR introduces (check all that apply):

- [x] 🐛 Bug Fix  
- [ ] ✨ New Feature  
- [x] ⚡ Enhancement / Optimization  
- [x] 🧰 Refactoring  
- [x] 🧾 Documentation Update  
- [ ] 🔧 Other (please specify): ____________

---

## ✅ Checklist

Before submitting your PR, please confirm the following:

- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added or updated relevant documentation.  
- [x] My changes do not break any existing functionality.  
- [x] I have tested my changes locally and they work as expected.  
- [x] I have linked all relevant issues (if any).

---

## 💬 Additional Notes (Optional)

Validation completed locally:
- `python manage.py check` passes in development mode
- production-mode guard correctly blocks startup when `SECRET_KEY` or `ALLOWED_HOSTS` are missing
- README and .env.example were updated to reflect the new setup requirements