### PR TITLE
Fix: Add missing hangman images for Hangman Hero game

### DIFF
--- a/frontend/public/games/Hangman Hero/images/0.svg
+++ b/frontend/public/games/Hangman Hero/images/0.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/images/1.svg
+++ b/frontend/public/games/Hangman Hero/images/1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="60" x2="220" y2="90" stroke="#666" stroke-width="2" stroke-dasharray="4,2"/>
+<circle cx="220" cy="110" r="20" fill="none" stroke="#333" stroke-width="3"/>
+<circle cx="213" cy="106" r="2" fill="#333"/>
+<circle cx="227" cy="106" r="2" fill="#333"/>
+<path d="M213 118 Q220 124 227 118" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/images/2.svg
+++ b/frontend/public/games/Hangman Hero/images/2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="60" x2="220" y2="90" stroke="#666" stroke-width="2" stroke-dasharray="4,2"/>
+<circle cx="220" cy="110" r="20" fill="none" stroke="#333" stroke-width="3"/>
+<circle cx="213" cy="106" r="2" fill="#333"/>
+<circle cx="227" cy="106" r="2" fill="#333"/>
+<path d="M213 118 Q220 124 227 118" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+<line x1="220" y1="130" x2="220" y2="200" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/images/3.svg
+++ b/frontend/public/games/Hangman Hero/images/3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="60" x2="220" y2="90" stroke="#666" stroke-width="2" stroke-dasharray="4,2"/>
+<circle cx="220" cy="110" r="20" fill="none" stroke="#333" stroke-width="3"/>
+<circle cx="213" cy="106" r="2" fill="#333"/>
+<circle cx="227" cy="106" r="2" fill="#333"/>
+<path d="M213 118 Q220 124 227 118" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+<line x1="220" y1="130" x2="220" y2="200" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="190" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/images/4.svg
+++ b/frontend/public/games/Hangman Hero/images/4.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="60" x2="220" y2="90" stroke="#666" stroke-width="2" stroke-dasharray="4,2"/>
+<circle cx="220" cy="110" r="20" fill="none" stroke="#333" stroke-width="3"/>
+<circle cx="213" cy="106" r="2" fill="#333"/>
+<circle cx="227" cy="106" r="2" fill="#333"/>
+<path d="M213 118 Q220 124 227 118" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+<line x1="220" y1="130" x2="220" y2="200" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="190" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="250" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/images/5.svg
+++ b/frontend/public/games/Hangman Hero/images/5.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="60" x2="220" y2="90" stroke="#666" stroke-width="2" stroke-dasharray="4,2"/>
+<circle cx="220" cy="110" r="20" fill="none" stroke="#333" stroke-width="3"/>
+<circle cx="213" cy="106" r="2" fill="#333"/>
+<circle cx="227" cy="106" r="2" fill="#333"/>
+<path d="M213 118 Q220 124 227 118" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+<line x1="220" y1="130" x2="220" y2="200" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="190" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="250" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="200" x2="195" y2="250" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/images/6.svg
+++ b/frontend/public/games/Hangman Hero/images/6.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" width="200" height="200">
+<line x1="40" y1="280" x2="260" y2="280" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="280" x2="100" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="100" y1="30" x2="220" y2="30" stroke="#333" stroke-width="4" stroke-linecap="round"/>
+<line x1="220" y1="30" x2="220" y2="60" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="60" x2="220" y2="90" stroke="#666" stroke-width="2" stroke-dasharray="4,2"/>
+<circle cx="220" cy="110" r="20" fill="none" stroke="#333" stroke-width="3"/>
+<circle cx="213" cy="106" r="2" fill="#333"/>
+<circle cx="227" cy="106" r="2" fill="#333"/>
+<path d="M213 118 Q220 124 227 118" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round"/>
+<line x1="220" y1="130" x2="220" y2="200" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="190" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="150" x2="250" y2="180" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="200" x2="195" y2="250" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+<line x1="220" y1="200" x2="245" y2="250" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/games/Hangman Hero/index.html
+++ b/frontend/public/games/Hangman Hero/index.html
@@ -12,7 +12,7 @@
 
     <div class="game-container">
         <div class="hangman">
-            <img id="hangman-img" src="images/0.png" alt="Hangman">
+            <img id="hangman-img" src="images/0.svg" alt="Hangman">
         </div>
 
         <div class="word" id="word"></div>

--- a/frontend/public/games/Hangman Hero/script.js
+++ b/frontend/public/games/Hangman Hero/script.js
@@ -16,7 +16,7 @@ function startGame() {
     guessedLetters = [];
     wrongAttempts = 0;
     statusText.textContent = "";
-    hangmanImg.src = `images/0.png`;
+    hangmanImg.src = `images/0.svg`;
     displayWord();
     generateKeyboard();
 }
@@ -52,7 +52,7 @@ function handleGuess(btn) {
         }
     } else {
         wrongAttempts++;
-        hangmanImg.src = `images/${wrongAttempts}.png`;
+        hangmanImg.src = `images/${wrongAttempts}.svg`;
 
         if (wrongAttempts >= maxAttempts) {
             statusText.textContent = `💀 Game Over! Word: ${selectedWord}`;


### PR DESCRIPTION
## Description
The Hangman Hero game referenced PNG image files (`images/0.png` through `images/6.png`) that were missing from the repository, causing broken image placeholders to display instead of the hangman figure.

## Changes
- Created 7 SVG hangman state images (`images/0.svg` through `images/6.svg`) with progressive stick figure drawing
- Updated `index.html` to reference `images/0.svg` instead of the missing `images/0.png`
- Updated `script.js` to use `.svg` extension for all hangman state images

The SVG images show the classic hangman progression:
- 0: Empty gallows
- 1-6: Progressive addition of head, body, arms, and legs

Closes #389