### PR TITLE
darken rock paper scissors theme

### DIFF
--- a/frontend/public/games/rps.html
+++ b/frontend/public/games/rps.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="dark">
 
 <head>
     <meta charset="UTF-8">
@@ -11,9 +11,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 
-<body class="bg-base-100 min-h-screen">
+<body class="bg-[#050508] min-h-screen text-white">
     <!-- Header -->
-    <div class="navbar bg-primary text-primary-content shadow-lg">
+    <div class="navbar bg-[#0f172a] text-white border-b border-white/10 shadow-lg">
         <div class="navbar-start">
             <!-- Changed the routing to home page -->
             <a href="/" class="btn btn-ghost">
@@ -34,17 +34,17 @@
     <div class="container mx-auto px-4 py-8">
         <div class="max-w-2xl mx-auto">
             <!-- Score Board -->
-            <div class="stats shadow mb-8 w-full">
+            <div class="stats shadow mb-8 w-full bg-white/5 border border-white/10">
                 <div class="stat">
-                    <div class="stat-title">Your Wins</div>
+                    <div class="stat-title text-gray-400">Your Wins</div>
                     <div class="stat-value text-primary" id="playerWins">0</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-title">Computer Wins</div>
+                    <div class="stat-title text-gray-400">Computer Wins</div>
                     <div class="stat-value text-secondary" id="computerWins">0</div>
                 </div>
                 <div class="stat">
-                    <div class="stat-title">Draws</div>
+                    <div class="stat-title text-gray-400">Draws</div>
                     <div class="stat-value text-accent" id="draws">0</div>
                 </div>
             </div>
@@ -84,15 +84,15 @@
                 <h3 class="text-xl font-bold mb-4">Make Your Choice:</h3>
                 <div class="flex justify-center gap-4 flex-wrap">
                     <button onclick="playGame('rock')"
-                        class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110 rps-button">
+                        class="btn btn-outline btn-lg border-white/10 text-white hover:btn-primary transition-all hover:scale-110 rps-button">
                         <span class="text-4xl mr-2">🪨</span>Rock
                     </button>
                     <button onclick="playGame('paper')"
-                        class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110 rps-button">
+                        class="btn btn-outline btn-lg border-white/10 text-white hover:btn-primary transition-all hover:scale-110 rps-button">
                         <span class="text-4xl mr-2">📄</span>Paper
                     </button>
                     <button onclick="playGame('scissors')"
-                        class="btn btn-outline btn-lg hover:btn-primary transition-all hover:scale-110 rps-button">
+                        class="btn btn-outline btn-lg border-white/10 text-white hover:btn-primary transition-all hover:scale-110 rps-button">
                         <span class="text-4xl mr-2">✂️</span>Scissors
                     </button>
                 </div>


### PR DESCRIPTION
## What changed
- Switched Rock Paper Scissors to the dark DaisyUI theme used across the rest of GameHub.
- Updated the page shell and cards so the navbar, score panels, and action buttons fit the neon dark styling.

## Why
- Issue #370 calls out that the page looks visually inconsistent with the site's dark theme.
- This keeps the game in the same visual language as the rest of the platform without changing gameplay logic.

## Validation
- `git diff --check -- frontend/public/games/rps.html`

Fixes #370