### PR TITLE
tighten 2048 desktop layout

### DIFF
--- a/frontend/public/games/2048.html
+++ b/frontend/public/games/2048.html
@@ -490,9 +490,9 @@
                 <!-- Floating Particles -->
                 <div class="particles" id="particles"></div>
 
-                <div class="flex flex-col lg:flex-row gap-6 items-start">
+                <div class="flex flex-col lg:flex-row gap-6 items-start lg:flex-nowrap">
                     <!-- Left Side - Stats and Rules -->
-                    <div class="lg:w-80 w-full">
+                    <div class="lg:w-72 w-full shrink-0">
                         <!-- Game Stats -->
                         <div class="stats shadow mb-4 w-full">
                             <div class="stat">
@@ -549,7 +549,7 @@
                     </div>
 
                     <!-- Center - Game Board -->
-                    <div class="game-container flex-1 max-w-2xl">
+                    <div class="game-container flex-1 min-w-0 max-w-xl">
                         <div class="text-center mb-4">
                             <h2 class="text-2xl font-bold mb-4">
                                 <span
@@ -641,7 +641,7 @@
                     </div>
 
                     <!-- Right Side - Additional Info -->
-                    <div class="lg:w-80 w-full">
+                    <div class="lg:w-72 w-full shrink-0">
                         <div class="game-container">
                             <h3 class="text-lg font-bold mb-3 text-center">
                                 <span


### PR DESCRIPTION
## What changed
- Reduced the desktop widths of the 2048 side panels so they stop forcing the layout to wrap under the board.
- Added `min-w-0` to the center column so the game area can actually shrink instead of pushing controls out of view.
- Kept the mobile behavior unchanged.

## Why
- Issue #375 reports that the 2048 page overflows on standard desktop viewports at 100% zoom.
- This keeps the board, controls, and side panels aligned on one row without extra vertical scrolling.

## Validation
- `git diff --check -- frontend/public/games/2048.html`

Fixes #375