### PR TITLE
refactor Tower of Hanoi state and rendering

### DIFF
--- a/frontend/public/games/Tower of Hanoi/index.html
+++ b/frontend/public/games/Tower of Hanoi/index.html
@@ -18,7 +18,7 @@
 <button id="resetBtn">Reset</button>
 
 <p id="moves">Moves: 0</p>
-<p id="message"></p>
+<p id="message" role="status" aria-live="polite"></p>
 
 <script src="script.js"></script>
 </body>

--- a/frontend/public/games/Tower of Hanoi/script.js
+++ b/frontend/public/games/Tower of Hanoi/script.js
@@ -1,93 +1,262 @@
-let pegs = document.querySelectorAll(".peg");
-let movesText = document.getElementById("moves");
-let message = document.getElementById("message");
-let resetBtn = document.getElementById("resetBtn");
+const CONFIG = {
+    pegCount: 3,
+    diskCount: 3,
+    diskHeight: 25,
+    diskGap: 30,
+    minDiskWidth: 60,
+    maxDiskWidth: 120,
+};
 
-let moves = 0;
+const dom = {
+    pegs: Array.from(document.querySelectorAll(".peg")),
+    movesText: document.getElementById("moves"),
+    message: document.getElementById("message"),
+    resetBtn: document.getElementById("resetBtn"),
+};
 
-// Initial disk setup
-let towers = [
-    [3, 2, 1], // Peg 0 (largest → smallest)
-    [],
-    []
-];
+const state = {
+    towers: createInitialTowers(),
+    moves: 0,
+    selectedPeg: null,
+    solved: false,
+};
 
-function render() {
-    pegs.forEach((peg, index) => {
-        peg.innerHTML = "";
-        towers[index].forEach((disk, i) => {
-            let d = document.createElement("div");
-            d.classList.add("disk", "disk" + disk);
-            d.style.bottom = `${i * 30}px`;
-            d.setAttribute("draggable", true);
-            d.dataset.disk = disk;
-            peg.appendChild(d);
-        });
-    });
+function createInitialTowers() {
+    return [
+        Array.from({ length: CONFIG.diskCount }, (_, index) => CONFIG.diskCount - index),
+        [],
+        [],
+    ];
 }
 
 function getTopDisk(pegIndex) {
-    let peg = towers[pegIndex];
+    const peg = state.towers[pegIndex];
     return peg[peg.length - 1];
 }
 
+function getDiskWidth(diskSize) {
+    if (CONFIG.diskCount === 1) {
+        return CONFIG.maxDiskWidth;
+    }
+
+    const ratio = (diskSize - 1) / (CONFIG.diskCount - 1);
+    return Math.round(
+        CONFIG.minDiskWidth + ratio * (CONFIG.maxDiskWidth - CONFIG.minDiskWidth)
+    );
+}
+
+function getDiskColor(diskSize) {
+    const ratio = (diskSize - 1) / Math.max(1, CONFIG.diskCount - 1);
+    const hue = 210 - Math.round(ratio * 130);
+    return `linear-gradient(135deg, hsl(${hue}, 78%, 60%), hsl(${hue - 8}, 70%, 42%))`;
+}
+
+function setMessage(text, tone = "info") {
+    dom.message.textContent = text;
+    dom.message.dataset.tone = tone;
+}
+
+function clearMessage() {
+    dom.message.textContent = "";
+    dom.message.dataset.tone = "info";
+}
+
+function updateHud() {
+    dom.movesText.innerText = `Moves: ${state.moves}`;
+}
+
+function isTowerSorted(tower) {
+    return tower.every((disk, index, arr) => index === 0 || arr[index - 1] > disk);
+}
+
+function isSolved() {
+    const target = state.towers[2];
+    return target.length === CONFIG.diskCount && isTowerSorted(target);
+}
+
+function updatePegAccessibility(peg, index) {
+    const isSelected = state.selectedPeg === index;
+    const diskCount = state.towers[index].length;
+
+    peg.setAttribute("role", "button");
+    peg.setAttribute("tabindex", "0");
+    peg.setAttribute(
+        "aria-label",
+        `Peg ${index + 1}, ${diskCount} disk${diskCount === 1 ? "" : "s"}${isSelected ? ", selected" : ""}`
+    );
+    peg.setAttribute("aria-pressed", isSelected ? "true" : "false");
+    peg.classList.toggle("selected", isSelected);
+}
+
+function createDiskElement(diskSize, position) {
+    const disk = document.createElement("div");
+    disk.classList.add("disk");
+    disk.draggable = true;
+    disk.dataset.disk = String(diskSize);
+    disk.style.bottom = `${position * CONFIG.diskGap}px`;
+    disk.style.width = `${getDiskWidth(diskSize)}px`;
+    disk.style.height = `${CONFIG.diskHeight}px`;
+    disk.style.background = getDiskColor(diskSize);
+    disk.setAttribute("aria-hidden", "true");
+    return disk;
+}
+
+function renderPeg(index) {
+    const peg = dom.pegs[index];
+    peg.innerHTML = "";
+
+    updatePegAccessibility(peg, index);
+
+    state.towers[index].forEach((diskSize, position) => {
+        peg.appendChild(createDiskElement(diskSize, position));
+    });
+}
+
+function renderAllPegs() {
+    dom.pegs.forEach((_, index) => renderPeg(index));
+}
+
 function canMove(from, to) {
-    let fromDisk = getTopDisk(from);
-    let toDisk = getTopDisk(to);
+    const fromDisk = getTopDisk(from);
+    const toDisk = getTopDisk(to);
 
     if (!fromDisk) return false;
     if (!toDisk) return true;
 
-    return fromDisk < toDisk; // Smaller disk only
+    return fromDisk < toDisk;
 }
 
-pegs.forEach((peg, index) => {
-    peg.addEventListener("dragstart", (e) => {
-        let pegIndex = index;
-        if (e.target.dataset.disk != getTopDisk(pegIndex)) {
-            e.preventDefault(); // Only top disk is draggable
-        } else {
-            e.dataTransfer.setData("fromPeg", pegIndex);
-        }
-    });
+function selectPeg(index) {
+    if (state.solved) return;
 
-    peg.addEventListener("dragover", (e) => e.preventDefault());
+    if (!getTopDisk(index)) {
+        setMessage("Choose a peg with a movable top disk.", "error");
+        return;
+    }
 
-    peg.addEventListener("drop", (e) => {
-        let from = parseInt(e.dataTransfer.getData("fromPeg"));
-        let to = index;
+    const previous = state.selectedPeg;
+    state.selectedPeg = index;
 
-        if (canMove(from, to)) {
-            let disk = towers[from].pop();
-            towers[to].push(disk);
-            moves++;
-            movesText.innerText = "Moves: " + moves;
-            message.innerText = "";
-            render();
-            checkWin();
-        } else {
-            message.innerText = "❌ Invalid Move!";
-            setTimeout(() => (message.innerText = ""), 1000);
-        }
-    });
-});
+    if (previous !== null && previous !== index) {
+        renderPeg(previous);
+    }
+    renderPeg(index);
 
-function checkWin() {
-    if (towers[2].length === 3) {
-        message.innerText = "🎉 Congratulations! Puzzle Solved!";
+    setMessage(`Peg ${index + 1} selected. Choose a destination peg.`, "info");
+}
+
+function clearSelection() {
+    const previous = state.selectedPeg;
+    state.selectedPeg = null;
+
+    if (previous !== null) {
+        renderPeg(previous);
     }
 }
 
-resetBtn.addEventListener("click", () => {
-    towers = [
-        [3, 2, 1],
-        [],
-        []
-    ];
-    moves = 0;
-    movesText.innerText = "Moves: 0";
-    message.innerText = "";
-    render();
+function attemptMove(from, to) {
+    if (state.solved) return false;
+
+    if (!canMove(from, to)) {
+        setMessage("❌ Invalid move!", "error");
+        return false;
+    }
+
+    const disk = state.towers[from].pop();
+    state.towers[to].push(disk);
+    state.moves += 1;
+
+    updateHud();
+    clearMessage();
+
+    renderPeg(from);
+    renderPeg(to);
+
+    if (isSolved()) {
+        state.solved = true;
+        setMessage("🎉 Congratulations! Puzzle Solved!", "success");
+    }
+
+    return true;
+}
+
+function handlePegAction(index) {
+    if (state.solved) return;
+
+    if (state.selectedPeg === null) {
+        selectPeg(index);
+        return;
+    }
+
+    if (state.selectedPeg === index) {
+        clearSelection();
+        clearMessage();
+        return;
+    }
+
+    const from = state.selectedPeg;
+    const moved = attemptMove(from, index);
+
+    if (moved) {
+        clearSelection();
+    }
+}
+
+dom.pegs.forEach((peg, index) => {
+    peg.addEventListener("click", () => handlePegAction(index));
+
+    peg.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            handlePegAction(index);
+        }
+    });
+
+    peg.addEventListener("dragstart", (event) => {
+        const topDisk = getTopDisk(index);
+        const targetDisk = event.target.dataset.disk;
+
+        if (!topDisk || String(topDisk) !== String(targetDisk)) {
+            event.preventDefault();
+            return;
+        }
+
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData("fromPeg", String(index));
+    });
+
+    peg.addEventListener("dragover", (event) => {
+        event.preventDefault();
+    });
+
+    peg.addEventListener("drop", (event) => {
+        event.preventDefault();
+
+        const from = parseInt(event.dataTransfer.getData("fromPeg"), 10);
+        const moved = attemptMove(from, index);
+
+        if (!moved && state.selectedPeg !== null) {
+            renderPeg(state.selectedPeg);
+        }
+    });
 });
 
-render();
+dom.resetBtn.addEventListener("click", resetGame);
+
+function resetGame() {
+    state.towers = createInitialTowers();
+    state.moves = 0;
+    state.selectedPeg = null;
+    state.solved = false;
+
+    updateHud();
+    clearMessage();
+    renderAllPegs();
+}
+
+function initGame() {
+    updateHud();
+    renderAllPegs();
+}
+
+initGame();

--- a/frontend/public/games/Tower of Hanoi/style.css
+++ b/frontend/public/games/Tower of Hanoi/style.css
@@ -19,6 +19,17 @@ body {
     border-radius: 10px;
     padding-top: 200px;
     position: relative;
+    outline: none;
+    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.peg:focus-visible {
+    box-shadow: 0 0 0 4px rgba(52, 152, 219, 0.35);
+}
+
+.peg.selected {
+    box-shadow: inset 0 0 0 3px rgba(52, 152, 219, 0.85), 0 0 0 4px rgba(52, 152, 219, 0.15);
+    transform: translateY(-2px);
 }
 
 .disk {
@@ -33,6 +44,18 @@ body {
 .disk1 { width: 60px; background: #3498db; }
 .disk2 { width: 90px; background: #f1c40f; }
 .disk3 { width: 120px; background: #e74c3c; }
+
+#message[data-tone="error"] {
+    color: #e74c3c;
+}
+
+#message[data-tone="info"] {
+    color: #3498db;
+}
+
+#message[data-tone="success"] {
+    color: #27ae60;
+}
 
 #resetBtn {
     padding: 10px 20px;


### PR DESCRIPTION
## Summary\n- Centralize Tower of Hanoi state into a single game state object\n- Update only affected pegs after a move instead of rebuilding the full board every time\n- Add keyboard-driven peg selection plus ARIA labels/live feedback for accessibility\n- Strengthen win validation by checking solved disk order, not just disk count\n- Replace hardcoded disk sizing with computed widths and themed colors\n\n## Validation\n- git diff --check -- frontend/public/games/Tower of Hanoi/index.html frontend/public/games/Tower of Hanoi/script.js frontend/public/games/Tower of Hanoi/style.css\n- node -e "const fs=require('fs'); new Function(fs.readFileSync('frontend/public/games/Tower of Hanoi/script.js','utf8')); console.log('parse ok')"\n\nCloses #403