### PR TITLE
Fix #425: Replace str(e) with generic messages in all 500 responses

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -162,8 +162,8 @@ def api_register(request):
                 'last_name': user.last_name,
             }
         }, status=status.HTTP_201_CREATED)
-    except Exception as e:
-        return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        return Response({'error': 'Registration failed. Please try again.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @extend_schema(
@@ -219,8 +219,8 @@ def api_forgot_password(request):
         
         try:
             send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [email])
-        except Exception as e:
-            return Response({'error': f'Failed to send email: {str(e)}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            return Response({'error': 'Failed to send email. Please try again later.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     # Return success message
     response_data = {'message': 'If an account exists with this email, a reset link has been sent.'}
@@ -412,8 +412,8 @@ def api_add_visit(request):
         profile.save()
         score = profile.visits + (profile.plays * 5)
         return Response({'status': 'success', 'visits': profile.visits, 'plays': profile.plays, 'score': score})
-    except Exception as e:
-        return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        return Response({'error': 'Failed to record visit. Please try again.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @extend_schema(
@@ -434,8 +434,8 @@ def api_add_play(request):
         profile.save()
         score = profile.visits + (profile.plays * 5)
         return Response({'status': 'success', 'visits': profile.visits, 'plays': profile.plays, 'score': score})
-    except Exception as e:
-        return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        return Response({'error': 'Failed to record play. Please try again.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @extend_schema(
@@ -473,8 +473,8 @@ def api_save_score(request):
             game_score.save()
             return Response({'status': 'success', 'message': 'New high score!', 'high_score': game_score.score})
         return Response({'status': 'success', 'message': 'Score saved', 'high_score': game_score.score})
-    except Exception as e:
-        return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        return Response({'error': 'Failed to save score. Please try again.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 # ============================================================
@@ -602,9 +602,9 @@ def api_google_login(request):
             status=status.HTTP_401_UNAUTHORIZED
         )
     except Exception as e:
-        logger.error(f"Google token verification unexpected error: {str(e)}", exc_info=True)
+        logger.error(f"Google token verification unexpected error: {e}", exc_info=True)
         return Response(
-            {'error': f'Could not verify Google token: {str(e)}'},
+            {'error': 'Could not verify Google token. Please try again.'},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
 
@@ -643,8 +643,8 @@ def api_google_login(request):
             is_new_user = True
             logger.info(f"New user created via Google: {username} ({verified_email})")
         except Exception as e:
-            logger.error(f"Failed to create user: {str(e)}", exc_info=True)
-            return Response({'error': f'Failed to create account: {str(e)}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            logger.error(f"Failed to create user: {e}", exc_info=True)
+            return Response({'error': 'Failed to create account. Please try again.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     else:
         updated = False
         if not user.first_name and verified_first_name:


### PR DESCRIPTION
## Description
Fixes #425 — Information disclosure via `str(e)` in 500 responses across 7 endpoints.

## Changes
Replaced `str(e)` with generic error messages in all `except Exception` handlers that returned internal error details to clients:

| Endpoint | Before | After |
|---|---|---|
| `POST /api/register` | `str(e)` | `Registration failed. Please try again.` |
| `POST /api/register` (Google OAuth user creation) | `f'Failed to create account: {str(e)}'` | `Failed to create account. Please try again.` |
| `POST /api/forgot-password` | `f'Failed to send email: {str(e)}'` | `Failed to send email. Please try again later.` |
| `POST /api/add-visit` | `str(e)` | `Failed to record visit. Please try again.` |
| `POST /api/add-play` | `str(e)` | `Failed to record play. Please try again.` |
| `POST /api/save-score` | `str(e)` | `Failed to save score. Please try again.` |
| `POST /api/google-login` (verification error) | `f'Could not verify Google token: {str(e)}'` | `Could not verify Google token. Please try again.` |

## Security
- All logging remains intact (server-side only — `logger.error(f"...: {e}")`)
- `ValueError` from Google OAuth still returns a contextual 401 message (auth error, not internal leak)
- No internal implementation details (DB errors, file paths, library versions) exposed to clients